### PR TITLE
[Bugfix] Component file name and manifest overwritting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,20 @@ The generator will ask for a component name (use "hyphen-case") and where to sav
 
 Finally, the generator will ask if you would like to overwrite a file; this file is the file which exports the component to the rest of the app. So you should accept it.
 
+## Developing
+
+To contribute with this repository:
+ - First you need to fork the project
+ - Create a branch with a meaningful name
+ - Modify the project as you see fit
+ - To test it manually, run:
+ ```
+ $ npm link
+ // It will link this module to current node_modules that has this module (problably global one)
+ ```
+ - run the command you want to see the changes (probably `yo qr component`)
+ - rinse and repeat :)
+ - Later, open a pull request to the main repository.
+
 ## Troubles & sugestions
 This is still a work in progress project, so please, if you find any problem or have some sugestion, don't hesitate to open an issue or even a pull request.

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -78,7 +78,7 @@ module.exports = class extends Generator {
   _createJavascriptFile(bindings) {
     this._copyTemplate(
       this._getTemplate('component-js.js'),
-      this._getDestinationPath(this._getComponentPath(), this._getFileName() + '.js'),
+      this._getDestinationPath(this._getComponentPath(), this._getFileName() + '.component.js'),
       bindings
     )
   }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -5,7 +5,7 @@ module.exports = class extends Generator {
     super(args, opts);
 
     this.argument('generatorType', { type: String, required: true });
-    
+
     this.DEFAULT_COMPONENT_PATH = 'qr-components';
   }
 
@@ -104,7 +104,7 @@ module.exports = class extends Generator {
       '/qr-components.manifest.js' : '/index.js';
 
     var filePath = this.destinationPath('app/javascript/src/modules/' + this.componentPath + indexFileName);
-    var content = 'export { ' + this._getComponentName() + " } from './" + this._getFileName() + "';\n";
+    var content = 'export { default as ' + this._getComponentName() + " } from './" + this._getFileName() + "';\n";
 
     this.fs.append(filePath, content);
   }


### PR DESCRIPTION
The command did not generate a `*.component.js` file.
Also, the index file must generate a `{ default as component }` kind of syntax.